### PR TITLE
Update AppliedEnergistics.zs

### DIFF
--- a/scripts/AppliedEnergistics.zs
+++ b/scripts/AppliedEnergistics.zs
@@ -12,7 +12,7 @@ val furnace = <minecraft:furnace>;
 val glowstone = <ore:dustGlowstone>;
 val diamond = <ore:gemDiamond>;
 val piston = <minecraft:piston>;
-val crafter = <ore:crafterWood>;
+val crafter = <ore:craftingTableWood>;
 val hopper = <ore:blockHopper>;
 
 val quartz = <appliedenergistics2:tile.BlockQuartzGlass>;


### PR DESCRIPTION
Currently recipes using the crafter entry in AE2 MT scripts will only use the Natura crafting table. Updated to include vanilla crafting table.
